### PR TITLE
uptest.sh: Make more Mac-friendly

### DIFF
--- a/uptest.sh
+++ b/uptest.sh
@@ -1,4 +1,8 @@
 #!/usr/bin/env bash
+if [ ! -d "$HOME/.nbsstate" ]; then
+  mkdir "$HOME/.nbsstate"
+fi
+
 SILENCE="$HOME/.nbsstate/SILENCE"
 SLEEP_DEFAULT=5
 LOGFILE_DEFAULT="$HOME/.nbsstate/uptest.log"
@@ -48,10 +52,11 @@ while [ 1 ]; do
       ms=0
     fi
     result="$ms ms\tfrom $dest"
-    logline="$ms\t$last"
+    #logline="$ms\t$last"
+    logline="1,\t$last"
   else
     result="**********DROPPED**********"
-    logline="0\t$last"
+    logline="0,\t$last"
     #sleeptime=5
   fi
   


### PR DESCRIPTION
Thanks for this! I wasn't able to get the Python code to work on OS X 10.8 for some reason (every logged ping started with a 0, regardless of whether not I could ping out), and my Python's not so great, so I tried the shell script instead. I had to make two tiny tweaks to be able to use the uptest.sh output with upmonitor.py. Maybe they're useful to you too...
- Create ~/.nbsstate if it doesn't already exist
- Change log format to match that of upmonitor.py
